### PR TITLE
UNC Path and Share Arguments to Snaffle Specific Shares

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ snaffcore/__pycache__/
 .vscode
 snafflepy/
 remotefiles/
+.snafflepy-venv/

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ options:
   -n, --disable-computer-discovery
                         Disable computer discovery, requires a list of hosts to do discovery on
   --no-download         Don't download files, just print found file names to stdout - this can only show the top level of files from the share and is unable to recurse into subdirectories.
+  -s SHARES, --shares SHARES
+                        Comma separated list of shares to scan. ie: hr,document,test
+  --unc UNC_PATH        Optional UNC path to a specific share. ie: \\192.168.1.1\hr
+
 ~~~
 
 ## Examples
@@ -61,6 +65,14 @@ options:
 2. Automatically discover the domain name and identify interesting shares and find a limited number of interesting files from them  
 
 `python3 snaffler.py <IP> -u <username> -p <password> -v`
+
+3. Scan specific shares across a target range
+
+`python3 snaffler.py <IP> -u <username> -p <password> -s hr,documents -n`
+
+4. Scan a specific UNC path directly
+
+`python3 snaffler.py --unc \\\\<IP>\\hr -u <username> -p <password>`
 
 ## Output
 

--- a/snaffcore/smb.py
+++ b/snaffcore/smb.py
@@ -48,7 +48,7 @@ class SMBClient:
                 # log.info(f'Found share {sharename} on {self.server}, remark {remarkname}')
 
                 if(self.share_names != None): # if shares are empty, then scan all shares (otherwise)
-                    if(not sharename in self.share_names.split(",")): # if share is not in our list of shares to scan, skip it
+                    if(not sharename in self.share_names): # if share is not in our list of shares to scan, skip it
                          continue
 
                 share_text = termcolor.colored("[Share]", 'light_yellow')

--- a/snaffler.py
+++ b/snaffler.py
@@ -10,6 +10,15 @@ from snaffcore.logger import *
 log = logging.getLogger('snafflepy')
 log.setLevel(logging.INFO)
 
+def parse_unc_path(value):
+    """Validate and parse UNC path in \\\\server\\share format, storing each part separately."""
+    if not value.startswith("\\\\"):
+        raise argparse.ArgumentTypeError(f"UNC path must start with \\\\, got: {value}")
+    parts = value.lstrip("\\").split("\\")
+    if len(parts) < 2:
+        raise argparse.ArgumentTypeError(f"UNC path must be in format \\\\server\\share, got: {value}")
+    return {"target": parts[0], "share": parts[1]}
+
 
 def parse_arguments():
     syntax_error = False
@@ -17,7 +26,7 @@ def parse_arguments():
 
     parser = argparse.ArgumentParser(
         add_help=True, prog='snaffler.py', description='A "port" of Snaffler in python')
-    parser.add_argument("targets", nargs='+', type=make_targets,
+    parser.add_argument("targets", nargs='*', type=make_targets,
                         help="IPs, hostnames, CIDR ranges, or files contains targets to snaffle. If you are providing more than one target, the -n option must be used.")
     parser.add_argument("-u", "--username",
                         type=str, help="domain username")
@@ -41,7 +50,9 @@ def parse_arguments():
     
     parser.add_argument("--no-download", action='store_true', help="Don't download files, just print found file names to stdout - this can only show the top level of files from the share and is unable to recurse into subdirectories.")
 
-    parser.add_argument("-s", "--shares", action="store_true", help="Comma separated list of shares to scan. ie: hr,document,test")
+    parser.add_argument("-s", "--shares", action="store", help="Comma separated list of shares to scan. ie: hr,document,test")
+
+    parser.add_argument("--unc", type=parse_unc_path,metavar="UNC_PATH", help=r"Optional UNC path to a specific share. ie: \\\\192.168.1.1\\hr")
 
     try:
         if len(sys.argv) <= 1:
@@ -63,11 +74,22 @@ def parse_arguments():
                 log.setLevel('DEBUG')
 
             targets = set()
-            [[targets.add(t) for t in g] for g in options.targets]
+            shares = set()
+            if options.unc:
+                targets.add(options.unc["target"])
+                shares.add(options.unc["share"])
+            if options.targets:
+                [[targets.add(t) for t in g] for g in options.targets]
+            if options.shares:
+                [shares.add(s.strip()) for s in options.shares.split(",") if s.strip()]
+            if not targets:
+                log.error("No targets specified. Provide at least one target or a --unc path.")
+                parser.print_help()
+                sys.exit(2)
             options.targets = list(targets)
-
+            options.shares = list(shares) if shares else None
             if len(options.targets) > 1 and not options.disable_computer_discovery:
-                log.error("If you have more than one target, then the -n option must be specified.")
+                log.error("If you are have more than one target, then the -n option must be specified.")
                 sys.exit(2)
             return options
 


### PR DESCRIPTION
## 🗣 Description ##
Added two new arguments to the argument parser:
- `-s` / `--shares`: accepts a comma-separated list of share names to scan (e.g. `hr,documents,test`)
- `--unc`: accepts a UNC path in `\\server\share` format to target a specific share directly

Both arguments feed into a unified `options.targets` and `options.shares` list, so the rest of the codebase handles them consistently regardless of how the user provided their input.

## 💭 Motivation and context ##
Previously, SnafflePy had no way to scope a scan to specific shares or target a single share via UNC path — it would always attempt to scan all discovered shares. This change allows users to narrow the scope of a scan, which is useful when:
- You already know which share you want to target
- You want to reduce noise and scan time by limiting to relevant shares
- You have a direct UNC path to a share and don't need full host/share discovery

## 🧪 Testing ##
The following cases were tested manually:

**Comma-separated shares:**
```bash
python3 snaffler.py 192.168.1.1 -u user -p pass -s hr,documents
# options.targets → ['192.168.1.1']
# options.shares  → ['hr', 'documents']
```

**Single share:**
```bash
python3 snaffler.py 192.168.1.1 -u user -p pass -s hr
# options.targets → ['192.168.1.1']
# options.shares  → ['hr']
```

**UNC path only:**
```bash
python3 snaffler.py --unc \\192.168.1.1\hr -u user -p pass
# options.targets → ['192.168.1.1']
# options.shares  → ['hr']
```

**UNC path combined with -s:**
```bash
python3 snaffler.py --unc \\192.168.1.1\hr -s documents -u user -p pass
# options.targets → ['192.168.1.1']
# options.shares  → ['hr', 'documents']
```
